### PR TITLE
Spiele von BGG laden und anzeigen

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,10 @@ gem "jbuilder"
 # Use Haml instead of HTML
 gem "haml-rails"
 
+gem "faraday"
+gem "faraday-httpclient"
+gem "faraday-decode_xml"
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,15 @@ GEM
       irb (>= 1.3.6)
       reline (>= 0.3.1)
     erubi (1.11.0)
+    faraday (2.6.0)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-decode_xml (0.2.1)
+      faraday (< 3.0)
+      multi_xml (< 1.0)
+    faraday-httpclient (2.0.1)
+      httpclient (>= 2.2)
+    faraday-net_http (3.0.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
     haml (6.0.8)
@@ -87,6 +96,7 @@ GEM
       activesupport (>= 5.1)
       haml (>= 4.0.6)
       railties (>= 5.1)
+    httpclient (2.8.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.1.5)
@@ -108,6 +118,7 @@ GEM
     mini_mime (1.1.2)
     minitest (5.16.3)
     msgpack (1.6.0)
+    multi_xml (0.6.0)
     net-imap (0.3.1)
       net-protocol
     net-pop (0.1.2)
@@ -158,6 +169,7 @@ GEM
     rake (13.0.6)
     reline (0.3.1)
       io-console (~> 0.5)
+    ruby2_keywords (0.0.5)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -193,6 +205,9 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   debug
+  faraday
+  faraday-decode_xml
+  faraday-httpclient
   haml-rails
   importmap-rails
   jbuilder

--- a/app/assets/stylesheets/_game_libraries.css
+++ b/app/assets/stylesheets/_game_libraries.css
@@ -1,0 +1,17 @@
+.GameLibrary_gamesList {
+  list-style: none;
+}
+
+.GameLibrary_gamesList_item {
+  margin-bottom: 20px;
+  padding: 5px;
+}
+
+.GameLibrary_gamesList_item:nth-child(odd) {
+  background-color: #ED458B;
+  color: white;
+}
+
+.GameLibrary_gamesList_item a {
+  color: inherit;
+}

--- a/app/assets/stylesheets/_games.css
+++ b/app/assets/stylesheets/_games.css
@@ -1,0 +1,60 @@
+.Game {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+
+.Game_picture {
+  width: 150px;
+  height: 150px;
+  object-fit: contain;
+}
+
+.Game_rating {
+  cursor: default;
+  position: relative;
+  width: 100px;
+  height: 57.73502691896258px;
+  background-color: #e4ecf4;
+  box-shadow: 0 0 0px rgba(0,255,255,1);
+  display: grid;
+  transition: 0s;
+}
+
+.Game_rating:before, .Game_rating:after {
+  content: "";
+  position: absolute;
+  z-index: 1;
+  width: 70.71067811865474px;
+  height: 70.71067811865474px;
+  transform: scaleY(0.5774) rotate(-45deg);
+  background-color: inherit;
+  left: 14.64466094067263px;
+  box-shadow: 0 0 0px rgba(0,255,255,1);
+  transition: 0s;
+}
+
+.Game_rating:before {
+  top: -35.35533905932737px;
+}
+.Game_rating:after {
+  bottom: -35.35533905932737px;
+}
+
+.Game_rating span {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  font-size: 32px;
+  color: #000;
+  font-family: monospace;
+  top: 0px;
+  left: 0;
+  width: 100px;
+  height: 57.7350px;
+  z-index: 2;
+  background: inherit;
+  transition: 0s;
+}

--- a/app/assets/stylesheets/_loader.css
+++ b/app/assets/stylesheets/_loader.css
@@ -1,0 +1,62 @@
+.lds-ellipsis {
+  display: inline-block;
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+
+.lds-ellipsis div {
+  position: absolute;
+  top: 33px;
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: #000;
+  animation-timing-function: cubic-bezier(0, 1, 1, 0);
+}
+
+.lds-ellipsis div:nth-child(1) {
+  left: 8px;
+  animation: lds-ellipsis1 0.6s infinite;
+}
+
+.lds-ellipsis div:nth-child(2) {
+  left: 8px;
+  animation: lds-ellipsis2 0.6s infinite;
+}
+.lds-ellipsis div:nth-child(3) {
+  left: 32px;
+  animation: lds-ellipsis2 0.6s infinite;
+}
+
+.lds-ellipsis div:nth-child(4) {
+  left: 56px;
+  animation: lds-ellipsis3 0.6s infinite;
+}
+
+@keyframes lds-ellipsis1 {
+  0% {
+    transform: scale(0);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes lds-ellipsis3 {
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(0);
+  }
+}
+
+@keyframes lds-ellipsis2 {
+  0% {
+    transform: translate(0, 0);
+  }
+  100% {
+    transform: translate(24px, 0);
+  }
+}

--- a/app/assets/stylesheets/_loading_animation.css
+++ b/app/assets/stylesheets/_loading_animation.css
@@ -1,0 +1,3 @@
+.LoadingAnimation_refreshLink.is-enhanced {
+  visibility: hidden;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,7 +15,6 @@
  */
 
 html {
-  max-width:70ch;
   padding:2ch;
   margin:auto;
   color:#333;

--- a/app/controllers/game_libraries_controller.rb
+++ b/app/controllers/game_libraries_controller.rb
@@ -15,6 +15,14 @@ class GameLibrariesController < ApplicationController
     @game_library = @player.build_game_library
   end
 
+  def update
+    @game_library = @player.game_library
+
+    BoardGameGeek::FetchCollectionJob.perform_later @game_library
+
+    render :show
+  end
+
   def create
     @game_library = @player.build_game_library(game_library_params)
 
@@ -22,6 +30,8 @@ class GameLibrariesController < ApplicationController
       if @game_library.save
         format.html { redirect_to player_game_library_url(player_id: @player), notice: "Ludothek wurde erfolgreich angelegt." }
         format.json { render :show, status: :created, location: @game_library }
+
+        BoardGameGeek::FetchCollectionJob.perform_later @game_library
       else
         format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @game_library.errors, status: :unprocessable_entity }

--- a/app/controllers/game_libraries_controller.rb
+++ b/app/controllers/game_libraries_controller.rb
@@ -1,0 +1,41 @@
+class GameLibrariesController < ApplicationController
+  before_action :set_player
+
+  def show
+    @game_library = @player.game_library
+
+    if @game_library
+      render :show
+    else
+      render :not_found, status: :not_found
+    end
+  end
+
+  def new
+    @game_library = @player.build_game_library
+  end
+
+  def create
+    @game_library = @player.build_game_library(game_library_params)
+
+    respond_to do |format|
+      if @game_library.save
+        format.html { redirect_to player_game_library_url(player_id: @player), notice: "Ludothek wurde erfolgreich angelegt." }
+        format.json { render :show, status: :created, location: @game_library }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @game_library.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  private
+
+  def set_player
+    @player = Player.find(params[:player_id])
+  end
+
+  def game_library_params
+    params.require(:game_library).permit(:bgg_username)
+  end
+end

--- a/app/controllers/game_nights_controller.rb
+++ b/app/controllers/game_nights_controller.rb
@@ -58,13 +58,14 @@ class GameNightsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_game_night
-      @game_night = GameNight.find(params[:id])
-    end
 
-    # Only allow a list of trusted parameters through.
-    def game_night_params
-      params.require(:game_night).permit(:title, :takes_place_at)
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_game_night
+    @game_night = GameNight.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def game_night_params
+    params.require(:game_night).permit(:title, :takes_place_at)
+  end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,0 +1,17 @@
+class GamesController < ApplicationController
+  before_action :set_game, only: %i[ show ]
+
+  def show
+    if request.headers['X-Embed-Link']
+      render :show, layout: false
+    else
+      render :show
+    end
+  end
+
+  private
+
+  def set_game
+    @game = Game.find(params[:id])
+  end
+end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -58,13 +58,14 @@ class PlayersController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_player
-      @player = Player.find(params[:id])
-    end
 
-    # Only allow a list of trusted parameters through.
-    def player_params
-      params.require(:player).permit(:name, :email, :nickname, :game_night_id)
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_player
+    @player = Player.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def player_params
+    params.require(:player).permit(:name, :email, :nickname, :game_night_id)
+  end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+import "./loading_animation"

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "./loading_animation"
+import "./embed_link"

--- a/app/javascript/embed_link.js
+++ b/app/javascript/embed_link.js
@@ -1,0 +1,46 @@
+/* eslint-env browser */
+
+class EmbedLink extends HTMLElement {
+  connectedCallback () {
+    this.loadContent();
+  }
+
+  loadContent (ev) {
+    this.classList.add("is-loading");
+
+    const rejectIfNotOK = (response) => {
+      return response.ok ? response : Promise.reject(new Error(response.statusText));
+    };
+
+    const headers = {
+      "X-Embed-Link": "True"
+    };
+
+    fetch(this.url, { credentials: "include", headers })
+      .then(rejectIfNotOK)
+      .then(response => response.text())
+      .then(text => {
+        this.classList.remove("is-loading");
+
+        // To ensure a correct loading of custom elements (and pony fills) it
+        // is necessary to invoke the fetched data via an html element object
+        this.outerHTML = text;
+
+        return null;
+      })
+      .catch((e) => {
+        this.remove();
+        console.error(`Failed to embed link ${this.url}`, e);
+      });
+
+    if (ev) {
+      ev.preventDefault();
+    }
+  }
+
+  get url () {
+    return this.querySelector("a").getAttribute("href");
+  }
+}
+
+customElements.define("embed-link", EmbedLink);

--- a/app/javascript/loading_animation.js
+++ b/app/javascript/loading_animation.js
@@ -1,0 +1,22 @@
+/* eslint-env browser */
+
+class LoadingAnimation extends HTMLElement {
+  connectedCallback () {
+    this.refreshLink.classList.add("is-enhanced");
+    setTimeout(this.refresh.bind(this), this.refreshDelay);
+  }
+
+  refresh () {
+    window.location.replace(this.refreshLink.href);
+  }
+
+  get refreshLink () {
+    return this.querySelector(".LoadingAnimation_refreshLink");
+  }
+
+  get refreshDelay () {
+    return parseInt(this.getAttribute("refresh-delay"), 10);
+  }
+}
+
+customElements.define("loading-animation", LoadingAnimation);

--- a/app/jobs/board_game_geek.rb
+++ b/app/jobs/board_game_geek.rb
@@ -1,0 +1,2 @@
+class BoardGameGeek
+end

--- a/app/jobs/board_game_geek/fetch_collection_job.rb
+++ b/app/jobs/board_game_geek/fetch_collection_job.rb
@@ -5,15 +5,14 @@ class BoardGameGeek::FetchCollectionJob < ApplicationJob
     bgg_service = BoardGameGeek::Service.new
 
     GameLibrary.transaction(requires_new: true) do
-      game_library.games.destroy_all
+      game_library.games = bgg_service.collection(username: game_library.bgg_username).map do |bgg_game|
+        game = Game.find_or_initialize_by(external_id: bgg_game.id)
+        game.name = bgg_game.name
+        game.picture_url = bgg_game.picture
+        game.rating = bgg_game.rating
+        game.save
 
-      bgg_service.collection(username: game_library.bgg_username).each do |bgg_game|
-        game_library.games.create(
-          name: bgg_game.name,
-          external_id: bgg_game.id,
-          picture_url: bgg_game.picture,
-          rating: bgg_game.rating
-        )
+        game
       end
     end
 

--- a/app/jobs/board_game_geek/fetch_collection_job.rb
+++ b/app/jobs/board_game_geek/fetch_collection_job.rb
@@ -1,0 +1,22 @@
+class BoardGameGeek::FetchCollectionJob < ApplicationJob
+  queue_as :default
+
+  def perform(game_library)
+    bgg_service = BoardGameGeek::Service.new
+
+    GameLibrary.transaction(requires_new: true) do
+      game_library.games.destroy_all
+
+      bgg_service.collection(username: game_library.bgg_username).each do |bgg_game|
+        game_library.games.create(
+          name: bgg_game.name,
+          external_id: bgg_game.id,
+          picture_url: bgg_game.picture,
+          rating: bgg_game.rating
+        )
+      end
+    end
+
+    game_library.update(bgg_sync_completed: true)
+  end
+end

--- a/app/models/board_game_geek.rb
+++ b/app/models/board_game_geek.rb
@@ -1,0 +1,2 @@
+class BoardGameGeek
+end

--- a/app/models/board_game_geek/game.rb
+++ b/app/models/board_game_geek/game.rb
@@ -1,0 +1,12 @@
+class BoardGameGeek
+  class Game
+    attr_reader :id, :name, :picture, :rating
+
+    def initialize(id:, name:, picture:, rating:)
+      @id = id
+      @name = name
+      @picture = picture
+      @rating = rating
+    end
+  end
+end

--- a/app/models/board_game_geek/service.rb
+++ b/app/models/board_game_geek/service.rb
@@ -12,7 +12,7 @@ class BoardGameGeek
           Game.new(
             id: item['objectid'],
             name: item.dig('name', '__content__'),
-            picture: item['image'],
+            picture: item['thumbnail'],
             rating: item.dig('stats', 'rating', 'bayesaverage', 'value').to_f
           )
         end

--- a/app/models/board_game_geek/service.rb
+++ b/app/models/board_game_geek/service.rb
@@ -1,0 +1,35 @@
+class BoardGameGeek
+  class Service
+    def collection(username:)
+      res = client.get("collection/#{username}", { own: 1 })
+
+      case res.status
+      when 202 # accepted
+        sleep 1
+        collection(username:)
+      when 200
+        res.body.dig('items', 'item').map do |item|
+          Game.new(
+            id: item['objectid'],
+            name: item.dig('name', '__content__'),
+            picture: item['image'],
+            rating: item.dig('stats', 'rating', 'bayesaverage', 'value').to_f
+          )
+        end
+      else
+        raise 'Something went wrong'
+      end
+    end
+
+    private
+
+    def client
+      return @client if @client
+
+      @client = Faraday.new(url: 'https://api.geekdo.com/xmlapi') do |f|
+        f.response :xml
+        f.adapter :httpclient
+      end
+    end
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,6 +1,5 @@
 class Game < ApplicationRecord
   has_many :game_libraries
-  has_many :owners, class_name: 'Player', foreign_key: 'player_id'
 
   validates :name, presence: true
   validates :external_id, presence: true

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,0 +1,9 @@
+class Game < ApplicationRecord
+  has_many :game_libraries
+  has_many :owners, class_name: 'Player', foreign_key: 'player_id'
+
+  validates :name, presence: true
+  validates :external_id, presence: true
+  validates :picture_url, presence: true
+  validates :rating, presence: true
+end

--- a/app/models/game_in_library.rb
+++ b/app/models/game_in_library.rb
@@ -1,0 +1,6 @@
+class GameInLibrary < ApplicationRecord
+  self.table_name = 'games_in_libraries'
+
+  belongs_to :game_library
+  belongs_to :game
+end

--- a/app/models/game_library.rb
+++ b/app/models/game_library.rb
@@ -1,0 +1,7 @@
+class GameLibrary < ApplicationRecord
+  belongs_to :player
+  has_many :games_in_libraries
+  has_many :games, through: :games_in_libraries
+
+  validates :bgg_username, presence: true
+end

--- a/app/models/game_library.rb
+++ b/app/models/game_library.rb
@@ -1,7 +1,7 @@
 class GameLibrary < ApplicationRecord
   belongs_to :player
-  has_many :games_in_libraries
-  has_many :games, through: :games_in_libraries
+  has_many :games_in_library, class_name: 'GameInLibrary', foreign_key: 'game_library_id'
+  has_many :games, through: :games_in_library
 
   validates :bgg_username, presence: true
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,6 +1,8 @@
 class Player < ApplicationRecord
   belongs_to :game_night, optional: true
 
+  has_one :game_library
+
   validates :name, presence: true
   validates :email, presence: true
   validates :nickname, presence: true

--- a/app/views/application/_loading_animation.html.haml
+++ b/app/views/application/_loading_animation.html.haml
@@ -1,0 +1,9 @@
+%loading-animation{ "refresh-delay": 2000 }
+  %aside
+    = yield
+    .lds-ellipsis
+      %div
+      %div
+      %div
+      %div
+    = link_to "Neuladen", refresh_url, class: "LoadingAnimation_refreshLink"

--- a/app/views/game_libraries/new.html.haml
+++ b/app/views/game_libraries/new.html.haml
@@ -1,0 +1,17 @@
+%h1 Neue Ludothek anlegen
+
+= form_with(model: @game_library, url: player_game_library_path(player_id: @player)) do |form|
+  - if @game_library.errors.any?
+    %article
+      %bold
+        = "#{@game_library.errors.count} Fehler haben das Speichern verhindert!"
+      %ul
+        - @game_library.errors.each do |error|
+          %li= error.full_message
+  %p
+    = form.label :bgg_username
+    = form.text_field :bgg_username
+
+  = form.submit
+
+= link_to "Abbrechen", player_path(@player)

--- a/app/views/game_libraries/not_found.html.haml
+++ b/app/views/game_libraries/not_found.html.haml
@@ -1,0 +1,3 @@
+%h1= "#{player.name} hat noch keine Ludothek 😢"
+
+%p Leg doch hier eine #{link_to("neue Ludothek", new_player_game_library_path(player_id: @player))} an!

--- a/app/views/game_libraries/show.html.haml
+++ b/app/views/game_libraries/show.html.haml
@@ -1,1 +1,10 @@
-%h1 Ludothek von #{@player.name}
+%h1 Ludothek von #{@player.name} (#{pluralize(@game_library.games.count, 'Spiel', plural: 'Spiele')})
+
+- if @game_library.bgg_sync_completed?
+- else
+  = render 'application/loading_animation', refresh_url: player_game_library_path(player_id: @player) do
+    %p
+      Daten werden von BoardGameGeek geladen
+
+    = button_to player_game_library_path(player_id: @player), method: "put" do
+      = "Ludothek von BGG laden"

--- a/app/views/game_libraries/show.html.haml
+++ b/app/views/game_libraries/show.html.haml
@@ -1,0 +1,1 @@
+%h1 Ludothek von #{@player.name}

--- a/app/views/game_libraries/show.html.haml
+++ b/app/views/game_libraries/show.html.haml
@@ -1,6 +1,10 @@
 %h1 Ludothek von #{@player.name} (#{pluralize(@game_library.games.count, 'Spiel', plural: 'Spiele')})
 
 - if @game_library.bgg_sync_completed?
+  %ul.GameLibrary_gamesList
+    - @game_library.games.each do |game|
+      %li.GameLibrary_gamesList_item
+        %embed-link= link_to game_path(game), game_path(game)
 - else
   = render 'application/loading_animation', refresh_url: player_game_library_path(player_id: @player) do
     %p

--- a/app/views/game_libraries/show.json.jbuilder
+++ b/app/views/game_libraries/show.json.jbuilder
@@ -1,0 +1,19 @@
+json.total_games @game_library.games.count
+
+json.games do
+  json.array! @game_library.games do |game|
+    json.url game_url(game)
+  end
+end
+
+json.bgg_sync do
+  json.completed @game_library.bgg_sync_completed
+  json.url player_game_library_url(player_id: @player)
+end
+
+json.player do
+  json.name @player.name
+  json.url player_url(@player)
+end
+
+json.url game_library(@game_library)

--- a/app/views/games/show.html.haml
+++ b/app/views/games/show.html.haml
@@ -1,0 +1,5 @@
+.Game
+  = image_tag @game.picture_url, class: "Game_picture"
+  .Game_name= link_to @game.name, game_path(@game)
+  .Game_rating
+    %span= number_with_precision(@game.rating, precision: 1)

--- a/app/views/games/show.json.jbuilder
+++ b/app/views/games/show.json.jbuilder
@@ -1,0 +1,5 @@
+json.extract! @game, :id, :name, :picture_url
+
+json.rating number_with_precision(@game.rating, precision: 1)
+
+json.url game_url(@game)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html
+%html{lang: "de"}
   %head
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title App

--- a/app/views/players/_player.html.haml
+++ b/app/views/players/_player.html.haml
@@ -11,3 +11,5 @@
   %p
     %strong Spieleabend:
     = player.game_night_id
+
+= link_to "Zur Ludothek von #{player.name}", player_game_library_path(player_id: player)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports.
-  config.consider_all_requests_local = false
+  config.consider_all_requests_local = true
 
   # Enable server timing
   config.server_timing = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports.
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = false
 
   # Enable server timing
   config.server_timing = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,6 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.active_job.queue_adapter = :async
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,6 +50,8 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
+  config.web_console.allowed_ips = ["172.0.0.0/8", "192.168.0.0/16"]
+
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,3 +5,5 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
+
+pin "app/javascript/loading_animation", to: "loading_animation.js", preload: true

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,9 +1,12 @@
 de:
   activerecord:
     models:
+      game_library: "Ludothek"
       game_night: "Spieleabend"
       player: "Spieler:in"
     attributes:
+      game_library:
+        bgg_username: "BGG Benutzername"
       game_night:
         title: "Titel"
         takes_place_at: "Wann geht es los?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   root 'game_nights#index'
 
-  resources :players
+  resources :players do
+    resource :game_library, only: %i(show new create)
+  end
+
   resources :game_nights
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root 'game_nights#index'
 
   resources :players do
-    resource :game_library, only: %i(show new create)
+    resource :game_library, only: %i(show new create update)
   end
 
   resources :game_nights

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,6 @@ Rails.application.routes.draw do
     resource :game_library, only: %i(show new create update)
   end
 
+  resources :games, only: %i(show)
   resources :game_nights
 end

--- a/db/migrate/20221105110751_create_games.rb
+++ b/db/migrate/20221105110751_create_games.rb
@@ -1,0 +1,12 @@
+class CreateGames < ActiveRecord::Migration[7.0]
+  def change
+    create_table :games do |t|
+      t.string :name
+      t.string :external_id
+      t.string :picture_url
+      t.float :rating
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221105111103_create_game_libraries.rb
+++ b/db/migrate/20221105111103_create_game_libraries.rb
@@ -1,0 +1,19 @@
+class CreateGameLibraries < ActiveRecord::Migration[7.0]
+  def change
+    create_table :game_libraries do |t|
+      t.belongs_to :player, foreign_key: true, null: false, unique: true
+
+      t.string :bgg_username, null: false
+      t.boolean :bgg_sync_completed, default: false
+
+      t.timestamps
+    end
+
+    create_table :games_in_libraries do |t|
+      t.belongs_to :game, foreign_key: true, null: false
+      t.belongs_to :game_library, foreign_key: true, null: false
+    end
+
+    add_index :games_in_libraries, [:game_library_id, :game_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,41 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_30_213021) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_05_111103) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "game_libraries", force: :cascade do |t|
+    t.bigint "player_id", null: false
+    t.string "bgg_username", null: false
+    t.boolean "bgg_sync_completed", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["player_id"], name: "index_game_libraries_on_player_id"
+  end
 
   create_table "game_nights", force: :cascade do |t|
     t.string "title"
     t.datetime "takes_place_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "games", force: :cascade do |t|
+    t.string "name"
+    t.string "external_id"
+    t.string "picture_url"
+    t.float "rating"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "games_in_libraries", force: :cascade do |t|
+    t.bigint "game_id", null: false
+    t.bigint "game_library_id", null: false
+    t.index ["game_id"], name: "index_games_in_libraries_on_game_id"
+    t.index ["game_library_id", "game_id"], name: "index_games_in_libraries_on_game_library_id_and_game_id", unique: true
+    t.index ["game_library_id"], name: "index_games_in_libraries_on_game_library_id"
   end
 
   create_table "players", force: :cascade do |t|
@@ -33,5 +59,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_30_213021) do
     t.index ["nickname"], name: "index_players_on_nickname", unique: true
   end
 
+  add_foreign_key "game_libraries", "players"
+  add_foreign_key "games_in_libraries", "game_libraries"
+  add_foreign_key "games_in_libraries", "games"
   add_foreign_key "players", "game_nights"
 end

--- a/public/404.html
+++ b/public/404.html
@@ -26,7 +26,7 @@
 <body>
   <!-- This file lives in public/404.html -->
   <p class="notice">
-    404 - Seite nicht gefunden
+    <strong>404</strong> - Seite nicht gefunden
   </p>
 </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -1,67 +1,32 @@
 <!DOCTYPE html>
-<html>
+<html lang="de">
 <head>
-  <title>The page you were looking for doesn't exist (404)</title>
+  <title>404 - Seite nicht gefunden</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="stylesheet" href="https://cdn.simplecss.org/simple.min.css">
   <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+   html {
+     max-width:70ch;
+     padding:2ch;
+     margin:auto;
+     color:#333;
+   }
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
+   .notice {
+     text-align: center;
+     background: var(--accent-bg);
+     border: 2px solid var(--border);
+     border-radius: 5px;
+     padding: 1.5rem;
+     margin: 2rem 0;
+   }
   </style>
 </head>
 
-<body class="rails-default-error-page">
+<body>
   <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
+  <p class="notice">
+    404 - Seite nicht gefunden
+  </p>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -1,66 +1,32 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <title>We're sorry, but something went wrong (500)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+<html lang="de">
+  <head>
+    <title>500 - Interner Fehler</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="stylesheet" href="https://cdn.simplecss.org/simple.min.css">
+    <style>
+     html {
+       max-width:70ch;
+       padding:2ch;
+       margin:auto;
+       color:#333;
+     }
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+     .notice {
+       text-align: center;
+       background: var(--accent-bg);
+       border: 2px solid var(--border);
+       border-radius: 5px;
+       padding: 1.5rem;
+       margin: 2rem 0;
+     }
+    </style>
+  </head>
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
-
-<body class="rails-default-error-page">
-  <!-- This file lives in public/500.html -->
-  <div class="dialog">
-    <div>
-      <h1>We're sorry, but something went wrong.</h1>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+  <body>
+    <!-- This file lives in public/500.html -->
+    <p class="notice">
+      <code>500</code> - Interner Fehler
+    </p>
+  </body>
 </html>


### PR DESCRIPTION
## Ziel

* Spieler:innen sollen ihre Ludothek von [BGG](https://boardgamegeek.com/) importieren können.
* Spiele können dabei mehreren Ludotheken zugeordnet werden
* Der Import der Daten von BGG soll außerhalb des Request / Response Zyklus implementiert werden
* Die Übersicht einer Ludothek und der ihr zugeordneten Spiele soll sowohl über HTML als auch JSON repräsentiert werden

## Umsetzung

* Als Übergangspunkt zwischen BGG und der Anwendung wurde ein `BoardGameGeek` Namensraum eingeführt.
* Das Laden eine `collection` von BGG ist nicht sofort möglich, sondern erfordert (mindestens) einen Folgerequest. Dies wurde eine rekusive Funktion mit `sleep` realisiert
* Hintergrund Prozess via `ActiveJob` zum Import der Daten von BGG
* Abhängig vom Import-Status wird die Ludothek angezeigt oder eine Interaktion zum erneuten Import geboten
* Die HTML Repräsentation der Ludothek beinhaltet nur Hyperlinks auf die einzelnen Spiel-Resourcen. Diese Hyperlinks werden via Javascript automatisch aufgelöst.
